### PR TITLE
Build devel dependencies with ASAN support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,6 @@ jobs:
           cmake --build build -j"$(nproc)"
 
       - name: Test
-        env:
-          # TODO: Investigate container overflow on CI
-          ASAN_OPTIONS: detect_container_overflow=0
         run: |
           ctest -V --test-dir build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
           cmake --build build -j"$(nproc)"
 
       - name: Test
+        env:
+          # TODO: Investigate container overflow on CI
+          ASAN_OPTIONS: detect_container_overflow=0
         run: |
           ctest -V --test-dir build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 build/
 
 # vcpkg
-vcpkg-configuration.json
 vcpkg-manifest-install.log
 vcpkg_installed/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,9 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "BUILD_TESTS": "ON",
         "BUILD_EXAMPLE": "ON",
-        "USE_ASAN": "ON"
+        "USE_ASAN": "ON",
+        "VCPKG_OVERLAY_TRIPLETS": "triplets",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-devel"
       }
     }
   ]

--- a/triplets/x64-linux-devel.cmake
+++ b/triplets/x64-linux-devel.cmake
@@ -1,0 +1,8 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CXX_FLAGS "-fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+set(VCPKG_C_FLAGS "-fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "73e9c8e73fbebbfecea912efbda2ec6475134dd1",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "73e9c8e73fbebbfecea912efbda2ec6475134dd1",
+    "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
+    "baseline": "73e9c8e73fbebbfecea912efbda2ec6475134dd1",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
In order to prevent some false positives from ASAN, we need to build dependencies with support for it. With this patch, vcpkg properly compiles all dependencies in this way.